### PR TITLE
Removed reference to ACCESS_KEYS.txt

### DIFF
--- a/Standalone/docker-compose.yml
+++ b/Standalone/docker-compose.yml
@@ -24,8 +24,8 @@ services:
     ports:
       - 8080:8080
       - 9080:9080
-    env_file:
-      - ACCESS_KEYS.txt
+#    env_file:
+#      - ACCESS_KEYS.txt
     restart: on-failure
     command: dgraph alpha --my=alpha:7080 --zero=zero:5080  --security whitelist=0.0.0.0/0
     container_name: alpha


### PR DESCRIPTION
Removed reference to ACCESS_KEYS.txt from the DGraph section of docker-compose.yml, this file contains AWS access keys used by DGraph when backing up and restoring from S3 via CLI/API

For the demo, backup and restore can be done through Ratel if required