### PR TITLE
Fix libre-gateway health check url

### DIFF
--- a/Standalone/docker-compose.yml
+++ b/Standalone/docker-compose.yml
@@ -200,7 +200,7 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
-      test: ["CMD", "curl", "-f", "http://libre-gateway:4000"]
+      test: ["CMD", "curl", "-f", "http://libre-gateway:4000/health"]
   grafana:
     image: grafana/grafana:latest
     container_name: grafana


### PR DESCRIPTION
Docker indicates that the `libre-gateway` service is unhealthy once running. This is due to the health check referencing `http://libre-gateway:4000/` which results in a 404. Nothing is serving this handler. There is a /health that results in a 200. This change updates the health check URL for `libre-gateway` to `http://libre-gateway:4000/health`

### Fix
- Fix libre-gateway health check url
